### PR TITLE
Add reservation cancel route and CSRF protection

### DIFF
--- a/seat-reservation-system/public/js/reservations.js
+++ b/seat-reservation-system/public/js/reservations.js
@@ -15,9 +15,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const formData = new FormData();
         formData.append('cancel_id', reservationId);
 
-        // Use current page URL or adjust path to your cancellation PHP handler
-        const response = await fetch(window.location.href, {
+        const response = await fetch(cancelUrl, {
           method: 'POST',
+          headers: {
+            'X-CSRF-TOKEN': csrfToken
+          },
           body: formData
         });
 

--- a/seat-reservation-system/resources/views/reservations.blade.php
+++ b/seat-reservation-system/resources/views/reservations.blade.php
@@ -3,10 +3,7 @@
 @section('content')
 <div class="page-wrapper" style="display: flex;">
 
-
-    
-
-    {{--style sheet --}}
+    {{-- Style sheet --}}
     <link rel="stylesheet" href="{{ asset('css/reservations.css') }}">
 
     {{-- Main content area --}}
@@ -36,8 +33,8 @@
                             <td>{{ $reservation->reservation_date }}</td>
                             <td class="status">{{ ucfirst($reservation->status) }}</td>
                             <td>
-                                <a href="#" 
-                                   class="cancel-btn" 
+                                <a href="#"
+                                   class="cancel-btn"
                                    data-reservation-id="{{ $reservation->reserve_id }}"
                                 >Cancel</a>
                             </td>
@@ -79,6 +76,11 @@
         </div>
     </div>
 </div>
+
+<script>
+    const cancelUrl = "{{ route('reservations.cancel') }}";
+    const csrfToken = "{{ csrf_token() }}";
+</script>
 
 <script src="{{ asset('js/reservations.js') }}"></script>
 @endsection

--- a/seat-reservation-system/resources/views/sidebar.blade.php
+++ b/seat-reservation-system/resources/views/sidebar.blade.php
@@ -11,7 +11,7 @@
         'intern' => [
             ["route" => "dashboard", "icon" => "fas fa-home", "text" => "Dashboard"],
             ["route" => "bookseat", "icon" => "fas fa-chair", "text" => "Book Seats"],
-            ["route" => "reservations", "icon" => "fas fa-calendar-alt", "text" => "My Reservations"],
+            ["route" => "reservations.index", "icon" => "fas fa-calendar-alt", "text" => "My Reservations"], // ✅ FIXED
             ["route" => "logout", "icon" => "fas fa-sign-out-alt", "text" => "Logout"], 
 
         ],

--- a/seat-reservation-system/routes/web.php
+++ b/seat-reservation-system/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\InternSeatController;
 use App\Http\Controllers\AdminSeatController;
 use App\Http\Controllers\ReportsController;
 use App\Http\Controllers\SeatBookingController;
+use App\Http\Controllers\ReservationController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -46,6 +47,11 @@ Route::middleware(['auth'])->group(function () {
 Route::middleware(['auth'])->group(function () {
     Route::post('/book-seat', [SeatBookingController::class, 'book'])->name('seat.book');
 });
+
+
+Route::get('/reservations', [ReservationController::class, 'view'])->name('reservations.index');
+Route::post('/reservations/cancel', [ReservationController::class, 'cancel'])->name('reservations.cancel');
+
 
 
 


### PR DESCRIPTION
Introduces a POST route for reservation cancellation and updates the frontend to use the correct URL and CSRF token for cancellation requests. Also fixes sidebar navigation to use the correct reservations route name.