### PR TITLE
Improve seat booking validation and UI feedback

### DIFF
--- a/seat-reservation-system/app/Http/Controllers/SeatBookingController.php
+++ b/seat-reservation-system/app/Http/Controllers/SeatBookingController.php
@@ -6,25 +6,16 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Models\Seat;
 use App\Models\Reservation;
-use Illuminate\Support\Facades\Log;
+use Carbon\Carbon;
 
 class SeatBookingController extends Controller
 {
     public function book(Request $request)
     {
-        try {
-            // Validate request input
-            $validated = $request->validate([
-                'seat_id' => 'required|integer|exists:seats,seat_id',
-                'date' => 'required|date',
-            ]);
-        } catch (\Illuminate\Validation\ValidationException $e) {
-            return response()->json([
-                'success' => false,
-                'message' => 'Validation failed',
-                'errors' => $e->errors(),
-            ], 422);
-        }
+        $validated = $request->validate([
+            'seat_id' => 'required|integer|exists:seats,seat_id',
+            'date' => 'required|date',
+        ]);
 
         $seatId = $validated['seat_id'];
         $date = $validated['date'];
@@ -33,13 +24,33 @@ class SeatBookingController extends Controller
         if (!$userId) {
             return response()->json([
                 'success' => false,
-                'message' => 'User not authenticated.'
+                'message' => 'You must be logged in to book a seat.'
             ], 401);
         }
 
-        // Find the seat with correct PK
-        $seat = Seat::where('seat_id', $seatId)->first();
+        $today = Carbon::today();
+        $selectedDate = Carbon::parse($date);
 
+        // ✅ 1. Past dates cannot be booked
+        if ($selectedDate->isPast()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'You cannot book a seat for a past date.'
+            ]);
+        }
+
+        // ✅ 2. Must book at least 1 hour in advance if booking for today
+        if ($selectedDate->isSameDay($today)) {
+            $now = Carbon::now();
+            if ($now->diffInMinutes($selectedDate->copy()->endOfDay()) < 60) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'You must book at least 1 hour in advance.'
+                ]);
+            }
+        }
+
+        $seat = Seat::find($seatId);
         if (!$seat) {
             return response()->json([
                 'success' => false,
@@ -47,35 +58,36 @@ class SeatBookingController extends Controller
             ], 404);
         }
 
-        if ($seat->status !== 'available') {
-            return response()->json([
-                'success' => false,
-                'message' => 'Seat already booked.'
-            ]);
-        }
-
-        // Check for duplicate reservation
-        $existing = Reservation::where('intern_id', $userId)
-            ->where('seat_id', $seatId)
+        // ✅ 3. Intern can only reserve one seat per day
+        $hasOtherBooking = Reservation::where('intern_id', $userId)
             ->where('reservation_date', $date)
             ->where('status', 'active')
-            ->first();
+            ->exists();
 
-        if ($existing) {
+        if ($hasOtherBooking) {
             return response()->json([
                 'success' => false,
-                'message' => 'You already booked this seat for this date.'
+                'message' => 'You have already reserved a seat for this day.'
             ]);
         }
 
-        // Mark seat as unavailable
-        $seat->status = 'unavailable';
-        $seat->save();
+        // ✅ 4. Seat cannot be reserved if already booked for that date
+        $isBooked = Reservation::where('seat_id', $seatId)
+            ->where('reservation_date', $date)
+            ->where('status', 'active')
+            ->exists();
 
-        // Create reservation
+        if ($isBooked) {
+            return response()->json([
+                'success' => false,
+                'message' => 'This seat is already booked for that date.'
+            ]);
+        }
+
+        // ✅ All clear → create reservation
         Reservation::create([
             'intern_id' => $userId,
-            'seat_id' => $seat->seat_id,
+            'seat_id' => $seatId,
             'reservation_date' => $date,
             'time_slot' => $request->input('time_slot', 'morning'),
             'status' => 'active',
@@ -83,7 +95,7 @@ class SeatBookingController extends Controller
 
         return response()->json([
             'success' => true,
-            'message' => 'Seat booked successfully.'
+            'message' => 'Seat booked successfully!'
         ]);
     }
 }

--- a/seat-reservation-system/public/js/intern_book_seats.js
+++ b/seat-reservation-system/public/js/intern_book_seats.js
@@ -2,62 +2,85 @@ document.addEventListener('DOMContentLoaded', function () {
   const overlay = document.querySelector('.overlay');
   const popup = document.getElementById('popup');
   const popupSeat = document.getElementById('popup-seat');
+  const confirmBtn = document.getElementById('confirm-booking');
+  const closeBtn = document.getElementById('close-popup');
+  const dateInput = document.getElementById('date');
   let selectedSeatId = null;
   let selectedSeatNum = null;
 
+  // Attach click only to available seats
   document.querySelectorAll('.seat.available').forEach(seat => {
-    seat.addEventListener('click', function() {
+    seat.addEventListener('click', function () {
       selectedSeatId = this.dataset.seatId;
       selectedSeatNum = this.dataset.seatNum;
 
-      popupSeat.textContent = "Seat: " + selectedSeatNum;
+      popupSeat.textContent = `Seat: ${selectedSeatNum}`;
       overlay.style.display = 'block';
       popup.style.display = 'block';
     });
   });
 
-  document.getElementById('confirm-booking').addEventListener('click', function() {
-    if (confirm(`Are you sure you want to book seat ${selectedSeatNum}?`)) {
+  confirmBtn.addEventListener('click', function () {
+    if (!selectedSeatId) return;
+
+    // Validate date input
+    const selectedDate = dateInput.value;
+    if (!selectedDate) {
+      alert('Please select a valid date.');
+      return;
+    }
+
+    if (confirm(`Are you sure you want to book seat ${selectedSeatNum} for ${selectedDate}?`)) {
+      // Disable confirm button to prevent multiple clicks
+      confirmBtn.disabled = true;
+
       fetch(bookingUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Accept': 'application/json', // VERY IMPORTANT!
+          'Accept': 'application/json',
           'X-CSRF-TOKEN': csrfToken
         },
         body: JSON.stringify({
           seat_id: selectedSeatId,
-          date: document.getElementById('date').value
+          date: selectedDate
         })
       })
-      .then(async response => {
-        if (!response.ok) {
-          const text = await response.text();
-          console.error('Server error:', text);
-          throw new Error('Server returned error');
-        }
-        return response.json();
-      })
-      .then(data => {
-        alert(data.message);
-        if (data.success) {
-          window.location.reload();
-        }
-      })
-      .catch(error => {
-        console.error('Error:', error);
-        alert('An error occurred while booking.');
-      });
-    }
+        .then(async response => {
+          if (!response.ok) {
+            const text = await response.text();
+            console.error('Server error:', text);
+            throw new Error('Server returned an error.');
+          }
+          return response.json();
+        })
+        .then(data => {
+          alert(data.message);
+          if (data.success) {
+            window.location.reload();
+          } else {
+            // Re-enable button if booking failed, so user can retry
+            confirmBtn.disabled = false;
+          }
+        })
+        .catch(error => {
+          console.error('Booking failed:', error);
+          alert('An error occurred while booking.');
+          confirmBtn.disabled = false;
+        });
 
-    closePopup();
+      closePopup();
+    }
   });
 
-  document.getElementById('close-popup').addEventListener('click', closePopup);
+  closeBtn.addEventListener('click', closePopup);
   overlay.addEventListener('click', closePopup);
 
   function closePopup() {
     overlay.style.display = 'none';
     popup.style.display = 'none';
+    confirmBtn.disabled = false;  // Reset confirm button state
+    selectedSeatId = null;
+    selectedSeatNum = null;
   }
 });

--- a/seat-reservation-system/resources/views/bookseat.blade.php
+++ b/seat-reservation-system/resources/views/bookseat.blade.php
@@ -38,39 +38,47 @@
     </form>
   </div>
 
-  <!-- Show all seats grouped by floor -->
+ @php
+  $floors = ['1st Floor', '2nd Floor', '3rd Floor', '4th Floor'];
+@endphp
+
+@forelse($floors as $floor)
   @php
-    $floors = ['1st Floor', '2nd Floor', '3rd Floor', '4th Floor'];
+    $floorSeats = $seats->where('location', $floor);
   @endphp
 
-  @forelse($floors as $floor)
-    @php
-      $floorSeats = $seats->where('location', $floor);
-    @endphp
+  @if ($selected_location == '' || $selected_location == $floor)
+    <div class="seats-layout">
+      <div class="seat-block">
+        <div class="block-title">{{ $floor }}</div>
+        <div class="grid">
+          @forelse ($floorSeats as $seat)
+            @php
+              $isBooked = $seat->reservations->where('reservation_date', $selected_date)
+                             ->where('status', 'active')->isNotEmpty();
+            @endphp
 
-    @if ($selected_location == '' || $selected_location == $floor)
-      <div class="seats-layout">
-        <div class="seat-block">
-          <div class="block-title">{{ $floor }}</div>
-          <div class="grid">
-            @foreach ($floorSeats as $seat)
-              <div class="seat {{ $seat->status == 'available' ? 'available' : 'unavailable' }}"
-                   data-seat-id="{{ $seat->seat_id }}"
-                   data-seat-num="{{ $seat->seat_num }}">
-                {{ $seat->seat_num }}
-              </div>
-            @endforeach
-          </div>
+            <div class="seat {{ $isBooked ? 'unavailable' : 'available' }}"
+                 data-seat-id="{{ $seat->seat_id }}"
+                 data-seat-num="{{ $seat->seat_num }}"
+                 style="{{ $isBooked ? 'pointer-events: none; cursor: not-allowed;' : '' }}">
+              {{ $seat->seat_num }}
+            </div>
+          @empty
+            <p>No seats found for this floor.</p>
+          @endforelse
         </div>
       </div>
-    @endif
-
-  @empty
-    <div class="no-seats">
-      <h3>No seats found</h3>
-      <p>Please try a different floor or date.</p>
     </div>
-  @endforelse
+  @endif
+@empty
+  <div class="no-seats">
+    <h3>No seats found</h3>
+    <p>Please try a different floor or date.</p>
+  </div>
+@endforelse
+
+
 </div>
 
 <!-- POPUP -->
@@ -87,7 +95,6 @@
   const csrfToken = "{{ csrf_token() }}";
 </script>
 <script src="{{ asset('js/intern_book_seats.js') }}"></script>
-
 
 </body>
 </html>


### PR DESCRIPTION
Added server-side checks to prevent booking for past dates, enforce booking at least 1 hour in advance, and restrict interns to one seat per day. Updated frontend to provide better feedback, validate date input, and prevent multiple booking attempts. Seat availability now reflects actual reservations for the selected date in the UI.